### PR TITLE
fjern stdlib fra jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,36 +164,7 @@
                             <classesDirectory>${basedir}/src/main/javadoc</classesDirectory>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>jar-without-dependencies</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <classifier>kotlin-client</classifier>
-                        </configuration>
-                    </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-assembly-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Det virker veldig feil å inkludere dependencies i jar-en. Dette skal jo maven håndtere. Men vi burde sikkert sjekke at dette funker når det inkluderes i både java- og kotlin-prosjekter før vi lager en release.