### PR TITLE
bump fuel til en nyere versjon som finnes i central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <java.version>11</java.version>
         <kotlin.version>1.3.70</kotlin.version>
-        <fuel.version>2.2.1</fuel.version>
+        <fuel.version>2.3.1</fuel.version>
         <jackson-module-kotlin.version>2.9.9</jackson-module-kotlin.version>
         <slf4j.version>1.7.25</slf4j.version>
         <maven.compiler.source>1.11</maven.compiler.source>


### PR DESCRIPTION
Får ofte feil i andre prosjekter da de ikke finner fuel.

```
Could not find artifact com.github.kittinunf.fuel:fuel:pom:2.2.1 in central (https://repo.maven.apache.org/maven2)
```