### PR TITLE
fiks støy fra proxy error pga ustabilitet

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/klient/error/ProxyError.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/klient/error/ProxyError.kt
@@ -26,11 +26,9 @@ open class ProxyError(
         }
 
         private fun parseBody(inputAsString: String): ProxyResponseIErrorBody {
-            if (inputAsString.isBlank()) {
-                return ProxyResponseIErrorBody(message = "", cause = "")
-            }
-
-            return try {
+            return if (inputAsString.isBlank()) {
+                ProxyResponseIErrorBody(message = "", cause = "")
+            } else try {
                 mapper.readValue(inputAsString)
             } catch (e: Exception) {
                 logger.warn("Kunne ikke parse response body `${inputAsString}`. Årsak: '${e.message}'", e)


### PR DESCRIPTION
Det er en del støy i loggene når man får 502 503 fra proxyen.
Endrer slik at vi håndterer tom body eksplisitt, og reduserer error til warn.
Flyttet også mapperen opp, slik at den ikke lages hver gang. Det koster en del å lage en ny mapper.