### PR TITLE
unngå tom melding ved feil fra altinn

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/klient/AltinnrettigheterProxyKlient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/klient/AltinnrettigheterProxyKlient.kt
@@ -193,7 +193,7 @@ class AltinnrettigheterProxyKlient(
                     else -> {
                         ProxyError(
                             httpStatus = e.response.status.value,
-                            melding = e.response.readText(),
+                            melding = e.message ?: e.response.status.toString(),
                             cause = "ukjent feil"
                         )
                     }


### PR DESCRIPTION
vi får fortsatt en del warn logger i appene våre som bruker klienten.

vi har planer om å rydde i klienten og forenkle feilhåndteringen, men i mellomtiden hadde det vært fint å lettere kunne se hva som er underliggende problem når det logges warn av typen: `Fikk exception i Altinn med følgende melding ''. Exception fra Altinn håndteres av klient applikasjon`

